### PR TITLE
показывать "Ответ пользователя:" вместо "Ваш ответ:" на странице /tes…

### DIFF
--- a/src/app/(main)/test-result/[id]/page.tsx
+++ b/src/app/(main)/test-result/[id]/page.tsx
@@ -1,6 +1,7 @@
 import TestResultAnswers from "@/components/testResult/Answers";
 import TestResultMetadata from "@/components/testResult/Metadata/Index";
 import TestResultContextProvider from "@/lib/contexts/testResult/Index/Provider";
+import getSignedInUser from "@/lib/fetchers/getSignedInUser";
 import getTestResult from "@/lib/fetchers/testResults/getTestResults";
 import { notFound } from "next/navigation";
 
@@ -9,17 +10,17 @@ type Context = {
 };
 
 export default async function TestResult(props: Context) {
-  const params = await props.params;
-
-  const {
-    id: testResultId
-  } = params;
+  const [params, signedInUser] = await Promise.all([
+    props.params,
+    getSignedInUser(),
+  ]);
+  const { id: testResultId } = params;
 
   const testResult = await getTestResult(testResultId);
   if (!testResult) notFound();
 
   return (
-    <TestResultContextProvider {...testResult}>
+    <TestResultContextProvider {...testResult} signedInUser={signedInUser}>
       <TestResultMetadata />
       <TestResultAnswers />
     </TestResultContextProvider>

--- a/src/components/testResult/IsCorrectSection/Index.tsx
+++ b/src/components/testResult/IsCorrectSection/Index.tsx
@@ -4,10 +4,12 @@ import useTestResultAnswerContext from "@/lib/hooks/testResult/answerContext";
 import testResultGetAnswers from "@/lib/testResult/getAnswers";
 import { cn } from "@/lib/shadcnUtils";
 import { TEST_QUESTION_TYPE } from "@/lib/types/enums/TestQuestionType";
+import useTestResultContext from "@/lib/hooks/testResult/context";
 
 type Props = {};
 
 export default function TestResultAnswerIsCorrectSection({}: Props) {
+  const testResult = useTestResultContext();
   const answerData = useTestResultAnswerContext();
   const answers = testResultGetAnswers(answerData);
   const correctAnswers = testResultGetCorrectAnswers(answerData);
@@ -20,7 +22,9 @@ export default function TestResultAnswerIsCorrectSection({}: Props) {
       <TestResultAnswerIsCorrectSectionBadge />
       <div className="flex flex-col">
         <span className="whitespace-nowrap text-muted-foreground">
-          Ваш ответ:
+          {testResult.userId === testResult.signedInUser?.id
+            ? "Ваш ответ:"
+            : "Ответ пользователя:"}
         </span>
         <div className="font-semibold">
           {!!answers?.length && (

--- a/src/lib/contexts/testResult/Index/Index.ts
+++ b/src/lib/contexts/testResult/Index/Index.ts
@@ -1,5 +1,7 @@
 import { TestResultGetTestResultReturn } from "@/lib/fetchers/testResults/getTestResults";
+import { User } from "@prisma/client";
 import { createContext } from "react";
 
-export const TestResultContext =
-  createContext<TestResultGetTestResultReturn | null>(null);
+export const TestResultContext = createContext<
+  (TestResultGetTestResultReturn & { signedInUser: User | null }) | null
+>(null);

--- a/src/lib/contexts/testResult/Index/Provider.tsx
+++ b/src/lib/contexts/testResult/Index/Provider.tsx
@@ -3,8 +3,13 @@
 import { TestResultGetTestResultReturn } from "@/lib/fetchers/testResults/getTestResults";
 import { PropsWithChildren } from "react";
 import { TestResultContext } from "./Index";
+import { User } from "@prisma/client";
 
-type Props = PropsWithChildren<TestResultGetTestResultReturn>;
+type Props = PropsWithChildren<
+  TestResultGetTestResultReturn & {
+    signedInUser: User | null;
+  }
+>;
 
 export default function TestResultContextProvider(props: Props) {
   return (

--- a/src/lib/fetchers/testResults/getTestResults.ts
+++ b/src/lib/fetchers/testResults/getTestResults.ts
@@ -5,7 +5,7 @@ const getTestResult = cache(async (id: string) => {
   return db.testResult.findFirst({
     where: { id },
     include: {
-      user: { select: { name: true } },
+      user: { select: { name: true, id: true } },
       test: {
         select: {
           id: true,


### PR DESCRIPTION
…t-result/[id], если пользователь, просматривающий результат теста, не был тем, кто его прошёл